### PR TITLE
Move contributing guidelines to its own `CONTRIBUTING.md` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+We welcome contributions to improve the library.
+All contributors must follow the steps and guidelines defined below.
+
+### Development Setup
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/daily3014/rbx-cryptography.git`
+3. Install dependencies if needed
+4. Start development server: `bash scripts/dev.sh`
+
+### Guidelines
+
+- **Bug Reports**: Use issues with reproduction steps
+- **Feature Requests**: Open an issue to discuss before implementing
+- **Pull Requests**: 
+  - Follow existing code style
+  - Add tests for new features
+  - Make sure all tests pass
+
+### Adding New Algorithms
+
+When contributing new cryptographic algorithms:
+1. Implement the algorithm in the appropriate module (Hashing, Encryption, etc.)
+2. Add tests
+4. Add performance benchmarks
+5. Submit a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,14 @@
 We welcome contributions to improve the library.
 All contributors must follow the steps and guidelines defined below.
 
-### Development Setup
+## Development Setup
 
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/daily3014/rbx-cryptography.git`
 3. Install dependencies if needed
 4. Start development server: `bash scripts/dev.sh`
 
-### Guidelines
+## Guidelines
 
 - **Bug Reports**: Use issues with reproduction steps
 - **Feature Requests**: Open an issue to discuss before implementing
@@ -19,7 +19,7 @@ All contributors must follow the steps and guidelines defined below.
   - Add tests for new features
   - Make sure all tests pass
 
-### Adding New Algorithms
+## Adding New Algorithms
 
 When contributing new cryptographic algorithms:
 1. Implement the algorithm in the appropriate module (Hashing, Encryption, etc.)

--- a/README.md
+++ b/README.md
@@ -360,31 +360,7 @@ This starts a Rojo server. Open Roblox Studio and sync Rojo into a Baseplate. Wh
 
 ## Contributing
 
-We welcome contributions to improve the library.
-
-### Development Setup
-
-1. Fork the repository
-2. Clone your fork: `git clone https://github.com/daily3014/rbx-cryptography.git`
-3. Install dependencies if needed
-4. Start development server: `bash scripts/dev.sh`
-
-### Guidelines
-
-- **Bug Reports**: Use issues with reproduction steps
-- **Feature Requests**: Open an issue to discuss before implementing
-- **Pull Requests**: 
-  - Follow existing code style
-  - Add tests for new features
-  - Make sure all tests pass
-
-### Adding New Algorithms
-
-When contributing new cryptographic algorithms:
-1. Implement the algorithm in the appropriate module (Hashing, Encryption, etc.)
-2. Add tests
-4. Add performance benchmarks
-5. Submit a pull request
+Please read the [CONTRIBUTING.md file](CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
Currently, the contributing guidelines are located in the `README.md` file.

As a best practice, contributing guidelines are usually placed in a separate file named `CONTRIBUTING.md`.

This PR moves the guidelines into their own dedicated `CONTRIBUTING.md` file.
